### PR TITLE
Typo, kurang huruf "x" untuk pengaturan pada file env

### DIFF
--- a/donjo-app/config/database.php
+++ b/donjo-app/config/database.php
@@ -80,7 +80,7 @@ $db['default'] = array(
 	'password' => $_ENV['database.default.password'] ?? 'root',
 	'database' => $_ENV['database.default.database'] ?? 'db_ataslangit_sid',
 	'dbdriver' => $_ENV['database.default.DBDriver'] ?? 'mysqli',
-	'dbprefix' => $_ENV['database.default.DBPrefi'] ?? '',
+	'dbprefix' => $_ENV['database.default.DBPrefix'] ?? '',
 	'pconnect' => FALSE,
 	'db_debug' => (ENVIRONMENT !== 'production'),
 	'cache_on' => FALSE,


### PR DESCRIPTION
**Deskripsi**
Typo, kurang huruf "x" untuk pengaturan pada file env

<!--
**Catatan**
- Pull requests tidak ada jaminan untuk dapat diterima
- Pull requests harap menjelaskan apa yang sedang diselesaikan
- Jika terkait issue yang sudah ada, harap mention issue tersebut contoh: "fix #12345"
-->
