### PR TITLE
👷 ci(phpmd): izinkan nama metode camel case

### DIFF
--- a/.github/phpmd.xml
+++ b/.github/phpmd.xml
@@ -16,6 +16,7 @@
     <rule ref="rulesets/design.xml"/>
         <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable"/>
+        <exclude name="CamelCaseMethodName"/>
     </rule>
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>


### PR DESCRIPTION
**Deskripsi**
- tambahkan pengecualian CamelCaseMethodName ke konfigurasi phpmd
- mencegah peringatan phpmd untuk metode yang menggunakan konvensi ini

<!--
**Catatan**
- Pull requests tidak ada jaminan untuk dapat diterima
- Pull requests harap menjelaskan apa yang sedang diselesaikan
- Jika terkait issue yang sudah ada, harap mention issue tersebut contoh: "fix #12345"
-->
