### PR TITLE
👷 ci(phpmd): perbarui aturan linter phpmd

### DIFF
--- a/.github/phpmd.xml
+++ b/.github/phpmd.xml
@@ -1,34 +1,55 @@
 <?xml version="1.0"?>
 <ruleset name="PHPMD rule set"
-         xmlns="http://pmd.sf.net/ruleset/1.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0
-                     http://pmd.sf.net/ruleset_xml_schema.xsd"
-         xsi:noNamespaceSchemaLocation="
-                     http://pmd.sf.net/ruleset_xml_schema.xsd">
-    <description>
-        PHPMD rule set for Ataslangit-SID project.
-    </description>
-
-    <rule ref="rulesets/cleancode.xml"/>
-    <rule ref="rulesets/codesize.xml"/>
-    <rule ref="rulesets/controversial.xml">
-        <exclude name="CamelCaseMethodName"/>
-        <exclude name="CamelCasePropertyName"/>
-        <exclude name="CamelCaseClassName"/>
-        <exclude name="CamelCaseVariableName"/>
-        <exclude name="CamelCaseParameterName"/>
-    </rule>
-    <rule ref="rulesets/design.xml"/>
-        <rule ref="rulesets/naming.xml">
-        <exclude name="ShortVariable"/>
-    </rule>
-    <rule ref="rulesets/naming.xml/ShortVariable">
+        xmlns="http://pmd.sf.net/ruleset/1.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+        xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>PHPMD rule set for Ataslangit-SID project.</description>
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag" />
+    <rule ref="rulesets/cleancode.xml/ElseExpression" />
+    <rule ref="rulesets/cleancode.xml/StaticAccess" />
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity" />
+    <rule ref="rulesets/codesize.xml/NPathComplexity" />
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength" />
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength" />
+    <rule ref="rulesets/codesize.xml/ExcessiveParameterList" />
+    <rule ref="rulesets/codesize.xml/ExcessivePublicCount" />
+    <rule ref="rulesets/codesize.xml/TooManyFields" />
+    <rule ref="rulesets/codesize.xml/TooManyMethods" />
+    <rule ref="rulesets/codesize.xml/TooManyPublicMethods" />
+    <rule ref="rulesets/codesize.xml/ExcessiveClassComplexity" />
+    <rule ref="rulesets/controversial.xml/Superglobals" />
+    <rule ref="rulesets/controversial.xml/CamelCasePropertyName">
         <properties>
-            <property name="minimum" value="3" />
+            <property name="allow-underscore" value="true" />
         </properties>
     </rule>
-    <rule ref="rulesets/unusedcode.xml"/>
+    <rule ref="rulesets/controversial.xml/CamelCaseMethodName">
+        <properties>
+            <property name="allow-underscore" value="true" />
+        </properties>
+    </rule>
+    <rule ref="rulesets/design.xml/ExitExpression" />
+    <rule ref="rulesets/design.xml/EvalExpression" />
+    <rule ref="rulesets/design.xml/GotoStatement" />
+    <rule ref="rulesets/design.xml/NumberOfChildren" />
+    <rule ref="rulesets/design.xml/DepthOfInheritance" />
+    <rule ref="rulesets/design.xml/CouplingBetweenObjects" />
+    <rule ref="rulesets/design.xml/DevelopmentCodeFragment" />
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="minimum" value="2" />
+        </properties>
+    </rule>
+    <rule ref="rulesets/naming.xml/LongVariable" />
+    <rule ref="rulesets/naming.xml/ShortMethodName" />
+    <rule ref="rulesets/naming.xml/ConstructorWithNameAsEnclosingClass" />
+    <rule ref="rulesets/naming.xml/ConstantNamingConventions" />
+    <rule ref="rulesets/naming.xml/BooleanGetMethodName" />
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateField" />
+    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable" />
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod" />
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter" />
 
     <exclude-pattern>*/donjo-sys/*</exclude-pattern>
 </ruleset>

--- a/.github/phpmd.xml
+++ b/.github/phpmd.xml
@@ -8,6 +8,8 @@
     <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag" />
     <rule ref="rulesets/cleancode.xml/ElseExpression" />
     <rule ref="rulesets/cleancode.xml/StaticAccess" />
+    <rule ref="rulesets/cleancode.xml/ErrorControlOperator" />
+    <rule ref="rulesets/cleancode.xml/DuplicatedArrayKey" />
     <rule ref="rulesets/codesize.xml/CyclomaticComplexity" />
     <rule ref="rulesets/codesize.xml/NPathComplexity" />
     <rule ref="rulesets/codesize.xml/ExcessiveMethodLength" />


### PR DESCRIPTION
**Deskripsi**
  - ganti import ruleset penuh dengan aturan spesifik
  - izinkan penggunaan underscore pada nama properti dan metode camel case
  - sesuaikan panjang minimum variabel pendek menjadi 2 karakter


<!--
**Catatan**
- Pull requests tidak ada jaminan untuk dapat diterima
- Pull requests harap menjelaskan apa yang sedang diselesaikan
- Jika terkait issue yang sudah ada, harap mention issue tersebut contoh: "fix #12345"
-->
