### PR TITLE
👷 ci(workflows): perbarui runner ubuntu ke versi terbaru

### DIFF
--- a/.github/workflows/composer-validate.yml
+++ b/.github/workflows/composer-validate.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   validate:
     name: Validate in PHP ${{ matrix.php-versions }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Deploy
     if: github.repository == 'ataslangit/sistem-informasi-desa'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Draft
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: Validate
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/phpmd.yml
+++ b/.github/workflows/phpmd.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read # for checkout to fetch code
       security-events: write # for github/codeql-action/upload-sarif to upload SARIF results

--- a/.github/workflows/pr-dependabot-merge.yml
+++ b/.github/workflows/pr-dependabot-merge.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     name: MERGE & LOCK
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: >-
       github.event.review.state == 'APPROVED' &&
       github.event.review.user.id == 2387514

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Validate
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -33,7 +33,7 @@ jobs:
         continue-on-error: true
         run: composer run psalm -- --report=psalm_report.sarif
 
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: psalm_report.sarif


### PR DESCRIPTION
**Deskripsi**
- tingkatkan versi ubuntu dari 22.04 ke 24.04 di semua workflow
- memastikan CI/CD berjalan di rilis LTS terbaru
- perbarui github/codeql-action/upload-sarif ke v4 di psalm.yml

<!--
**Catatan**
- Pull requests tidak ada jaminan untuk dapat diterima
- Pull requests harap menjelaskan apa yang sedang diselesaikan
- Jika terkait issue yang sudah ada, harap mention issue tersebut contoh: "fix #12345"
-->
