### PR TITLE
Potential fix for code scanning alert no. 17593: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,4 +1,6 @@
 name: PHP-CS-FIXER
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ataslangit/sistem-informasi-desa/security/code-scanning/17593](https://github.com/ataslangit/sistem-informasi-desa/security/code-scanning/17593)

The best way to fix this issue is to add the `permissions` key to the workflow at either the root (level with `name` and `on`) or within the specific job requiring restricted/expanded permissions. Since this workflow only validates PHP code formatting and does not appear to need write access to repository content, the minimal permissions set should be `contents: read`, which allows jobs to fetch source code but not to push, modify, or create security exposures. Edit the `.github/workflows/php-cs-fixer.yml` file and insert the following block directly below the workflow `name` (on line 2, before `on:`) to apply the permissions to all jobs in this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
