### PR TITLE
Potential fix for code scanning alert no. 17592: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,6 @@
 name: Docs
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/ataslangit/sistem-informasi-desa/security/code-scanning/17592](https://github.com/ataslangit/sistem-informasi-desa/security/code-scanning/17592)

The best way to fix this issue is to explicitly specify the required permissions for the job or the workflow. In this case, the workflow performs documentation deployment by using a deploy key via `peaceiris/actions-gh-pages@v4`, meaning that the workflow likely does not need write privileges on the `GITHUB_TOKEN`. The minimal safe permissions are `contents: read`. You should add a `permissions` block at the workflow root (for all jobs) or at the job level (under `build:`). Adding it at the root applies strict permissions to all jobs unless a job overrides them, which is usually preferable for consistent security. Insert the following after the `name:` line and before the `on:` block in `.github/workflows/deploy-docs.yml`:

```yaml
permissions:
  contents: read
```

The file to edit is `.github/workflows/deploy-docs.yml`. No additional imports, method or variable definitions, or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
