### PR TITLE
Potential fix for code scanning alert no. 17591: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - "*"
 
+permissions:
+  contents: write
 jobs:
   build:
     name: Draft


### PR DESCRIPTION
Potential fix for [https://github.com/ataslangit/sistem-informasi-desa/security/code-scanning/17591](https://github.com/ataslangit/sistem-informasi-desa/security/code-scanning/17591)

To fix this problem, you should specify a `permissions` block with the least privileges required for your job. Since your workflow is creating a release draft and uploading an artifact, it needs write access to repository contents. Add this block either at the top level (applies to all jobs) or under the specific job (in this case, only one job exists). The best way is to add 
```yaml
permissions:
  contents: write
```
at the workflow root (just after the name/on blocks but before jobs). Alternatively, if you expect to add other jobs later with different permissions, you could add it inside the `build:` job block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
